### PR TITLE
Prevent overriding user settings on every restart

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -112,10 +112,10 @@ async function activate(context) {
   if (!hasRunBefore) {
     await applySettings(true);
     await context.globalState.update(HAS_RUN_KEY, true);
-    vscode.commands.executeCommand("minimalBlue.showWelcome");
-  } else {
-    // On subsequent runs, just ensure the UI settings are active (don't force theme)
-    applySettings(false);
+    // Use a small delay to ensure VS Code's UI is ready before showing the welcome page
+    setTimeout(() => {
+      vscode.commands.executeCommand("minimalBlue.showWelcome");
+    }, 1000);
   }
 
   // Register the manual command
@@ -129,7 +129,8 @@ async function activate(context) {
     vscode.workspace.onDidChangeConfiguration(async (event) => {
       if (event.affectsConfiguration("workbench.colorTheme")) {
         const theme = vscode.workspace.getConfiguration().get("workbench.colorTheme");
-        if (theme && theme.startsWith("Minimal Blue")) {
+        if (theme && (theme === "Minimal Blue" || theme === "Minimal Blue (Super Dark)")) {
+          // User explicitly selected the theme, so we can suggest/apply settings
           await applySettings(false);
         }
       }


### PR DESCRIPTION
## fix: stop overriding user settings on restart (#6)

### Key Changes

- **Activation Logic**
  - Updated `activate()` to apply settings **only on first install** or when the user explicitly selects a *Minimal Blue* theme variant.

- **Persistence**
  - Removed automatic `applySettings(false)` on every activation.
  - Ensures user customizations (e.g., sidebar position, menu visibility) are preserved across restarts.

- **UX Improvement**
  - Added a slight delay before showing the welcome page on first run.
  - Prevents UI glitches by allowing VS Code to fully load first.

### Fixes
- Closes #6